### PR TITLE
WIP: Reduce issues found by static analyzers

### DIFF
--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -21,7 +21,7 @@ abstract class AbstractFactory
     }
 
     /**
-     * @return mixed
+     * @return object
      */
     public function __invoke(ContainerInterface $container)
     {
@@ -68,14 +68,14 @@ abstract class AbstractFactory
     /**
      * Returns the default config.
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     abstract protected function getDefaultConfig(string $configKey) : array;
 
     /**
      * Retrieves the config for a specific section.
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     protected function retrieveConfig(ContainerInterface $container, string $configKey, string $section) : array
     {

--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -21,7 +21,7 @@ abstract class AbstractFactory
     }
 
     /**
-     * @return object
+     * @return mixed
      */
     public function __invoke(ContainerInterface $container)
     {
@@ -95,6 +95,8 @@ abstract class AbstractFactory
      *
      * If the container does not know about the dependency, it is pulled from a fresh factory. This saves the user from
      * registering factories which they are not gonna access themself at all, and thus minimized configuration.
+     *
+     * @param string|class-string $factoryClassName
      *
      * @return mixed
      */

--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -96,9 +96,9 @@ abstract class AbstractFactory
      * If the container does not know about the dependency, it is pulled from a fresh factory. This saves the user from
      * registering factories which they are not gonna access themself at all, and thus minimized configuration.
      *
-     * @param string|class-string $factoryClassName
-     *
      * @return mixed
+     *
+     * @psalm-param class-string<AbstractFactory> $factoryClassName
      */
     protected function retrieveDependency(ContainerInterface $container, string $configKey, string $section, string $factoryClassName)
     {

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -33,7 +33,7 @@ final class CacheFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         $config = $this->retrieveConfig($container, $configKey, 'cache');
 

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -16,7 +16,6 @@ use Doctrine\Common\Cache\PhpFileCache;
 use Doctrine\Common\Cache\PredisCache;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\Cache\WinCacheCache;
-use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\Common\Cache\ZendDataCache;
 use Doctrine\Common\Proxy\Exception\OutOfBoundsException;
 use Psr\Container\ContainerInterface;
@@ -141,11 +140,6 @@ final class CacheFactory extends AbstractFactory
             case 'wincache':
                 return [
                     'class' => WinCacheCache::class,
-                    'namespace' => 'psr-container-doctrine',
-                ];
-            case 'xcache':
-                return [
-                    'class' => XcacheCache::class,
                     'namespace' => 'psr-container-doctrine',
                 ];
             case 'zenddata':

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -57,7 +57,7 @@ final class CacheFactory extends AbstractFactory
 
             case ChainCache::class:
                 $providers = array_map(
-                    function ($provider) use ($container) : Cache {
+                    function ($provider) use ($container) : CacheProvider {
                         return $this->createWithConfig($container, $provider);
                     },
                     is_array($config['providers']) ? $config['providers'] : []

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -16,8 +16,8 @@ use Doctrine\Common\Cache\PredisCache;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\Cache\WinCacheCache;
 use Doctrine\Common\Cache\ZendDataCache;
-use Doctrine\Common\Proxy\Exception\OutOfBoundsException;
 use Psr\Container\ContainerInterface;
+use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
 use function array_key_exists;
 use function array_map;
 use function is_array;
@@ -57,7 +57,7 @@ final class CacheFactory extends AbstractFactory
 
             case ChainCache::class:
                 $providers = array_map(
-                    function ($provider) use ($container): Cache {
+                    function ($provider) use ($container) : Cache {
                         return $this->createWithConfig($container, $provider);
                     },
                     is_array($config['providers']) ? $config['providers'] : []

--- a/src/ConfigurationFactory.php
+++ b/src/ConfigurationFactory.php
@@ -20,7 +20,7 @@ final class ConfigurationFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         $config = $this->retrieveConfig($container, $configKey, 'configuration');
 
@@ -147,7 +147,7 @@ final class ConfigurationFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultConfig($configKey) : array
+    protected function getDefaultConfig(string $configKey) : array
     {
         return [
             'metadata_cache' => 'array',

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -23,7 +23,7 @@ final class ConnectionFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         $this->registerTypes($container);
 
@@ -69,7 +69,7 @@ final class ConnectionFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultConfig($configKey) : array
+    protected function getDefaultConfig(string $configKey) : array
     {
         return [
             'driver_class' => PdoMysqlDriver::class,

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -36,7 +36,7 @@ final class DriverFactory extends AbstractFactory
             $config['paths'] = [$config['paths']];
         }
 
-        if ($config['class'] === AnnotationDriver::class || is_subclass_of($config['class'], AnnotationDriver::class)) {
+        if (is_subclass_of($config['class'], AnnotationDriver::class)) {
             $driver = new $config['class'](
                 new CachedReader(
                     new AnnotationReader(),

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -6,12 +6,12 @@ namespace Roave\PsrContainerDoctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
-use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
-use Doctrine\Common\Proxy\Exception\OutOfBoundsException;
+use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Psr\Container\ContainerInterface;
+use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
 use function array_key_exists;
 use function class_exists;
 use function is_array;

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -13,7 +13,6 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Psr\Container\ContainerInterface;
 use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
 use function array_key_exists;
-use function class_exists;
 use function is_array;
 use function is_subclass_of;
 

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -25,7 +25,7 @@ final class DriverFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         $config = $this->retrieveConfig($container, $configKey, 'driver');
 
@@ -81,7 +81,7 @@ final class DriverFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultConfig($configKey) : array
+    protected function getDefaultConfig(string $configKey) : array
     {
         return [
             'paths' => [],

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -46,9 +46,7 @@ final class DriverFactory extends AbstractFactory
             );
         }
 
-        if ($config['extension'] !== null
-            && ($config['class'] === FileDriver::class || is_subclass_of($config['class'], FileDriver::class))
-        ) {
+        if ($config['extension'] !== null && is_subclass_of($config['class'], FileDriver::class)) {
             $driver = new $config['class']($config['paths'], $config['extension']);
         }
 

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Roave\PsrContainerDoctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
@@ -23,9 +22,6 @@ use function is_subclass_of;
  */
 final class DriverFactory extends AbstractFactory
 {
-    /** @var bool */
-    private static $isAnnotationLoaderRegistered = false;
-
     /**
      * {@inheritdoc}
      */
@@ -42,8 +38,6 @@ final class DriverFactory extends AbstractFactory
         }
 
         if ($config['class'] === AnnotationDriver::class || is_subclass_of($config['class'], AnnotationDriver::class)) {
-            $this->registerAnnotationLoader();
-
             $driver = new $config['class'](
                 new CachedReader(
                     new AnnotationReader(),
@@ -94,23 +88,5 @@ final class DriverFactory extends AbstractFactory
             'extension' => null,
             'drivers' => [],
         ];
-    }
-
-    /**
-     * Registers the annotation loader
-     */
-    private function registerAnnotationLoader() : void
-    {
-        if (self::$isAnnotationLoaderRegistered) {
-            return;
-        }
-
-        AnnotationRegistry::registerLoader(
-            static function ($className) {
-                return class_exists($className);
-            }
-        );
-
-        self::$isAnnotationLoaderRegistered = true;
     }
 }

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -15,7 +15,7 @@ final class EntityManagerFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         $config = $this->retrieveConfig($container, $configKey, 'entity_manager');
 
@@ -38,7 +38,7 @@ final class EntityManagerFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultConfig($configKey) : array
+    protected function getDefaultConfig(string $configKey) : array
     {
         return [
             'connection' => $configKey,

--- a/src/EventManagerFactory.php
+++ b/src/EventManagerFactory.php
@@ -26,7 +26,7 @@ final class EventManagerFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         $config       = $this->retrieveConfig($container, $configKey, 'event_manager');
         $eventManager = new EventManager();
@@ -106,7 +106,7 @@ final class EventManagerFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultConfig($configKey) : array
+    protected function getDefaultConfig(string $configKey) : array
     {
         return [
             'subscribers' => [],

--- a/test/AbstractFactoryTest.php
+++ b/test/AbstractFactoryTest.php
@@ -62,7 +62,7 @@ class AbstractFactoryTest extends TestCase
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function configProvider() : array
     {

--- a/test/ConnectionFactoryTest.php
+++ b/test/ConnectionFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RoaveTest\PsrContainerDoctrine;
 
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Driver\PDOMySql\Driver as PDOMySQLDriver;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -54,7 +55,7 @@ class ConnectionFactoryTest extends TestCase
             $factory($container->reveal());
         } catch (ConnectionException $e) {
             foreach ($e->getTrace() as $entry) {
-                if ($entry['class'] === 'Doctrine\DBAL\Driver\PDOMySql\Driver') {
+                if ($entry['class'] === PDOMySQLDriver::class) {
                     $this->addToAssertionCount(1);
 
                     return;
@@ -175,16 +176,14 @@ class ConnectionFactoryTest extends TestCase
     }
 
     /**
-     * @param mixed[] $config
-     *
-     * @return ContainerInterface|ObjectProphecy
+     * @param array<string, mixed> $config
      */
     private function buildContainer(
         string $ownKey = 'orm_default',
         string $configurationKey = 'orm_default',
         string $eventManagerKey = 'orm_default',
         array $config = []
-    ) {
+    ) : ObjectProphecy {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn([

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace RoaveTest\PsrContainerDoctrine;
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\ORM\Mapping\Driver;
-use OutOfBoundsException;
+use Doctrine\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Roave\PsrContainerDoctrine\DriverFactory;
+use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
 
 class DriverFactoryTest extends TestCase
 {
@@ -44,10 +45,13 @@ class DriverFactoryTest extends TestCase
         $factory = new DriverFactory();
 
         $driver = $factory($container->reveal());
+        $this->assertInstanceOf(FileDriver::class, $driver);
         $this->assertSame($globalBasename, $driver->getGlobalBasename());
     }
 
     /**
+     * @param string|class-string $driverClass
+     *
      * @dataProvider simplifiedDriverClassProvider
      */
     public function testItSupportsSettingExtensionInDriversUsingSymfonyFileLocator(string $driverClass) : void
@@ -67,10 +71,8 @@ class DriverFactoryTest extends TestCase
             ],
         ]);
 
-        $factory = new DriverFactory();
-
-        $driver = $factory($container->reveal());
-        $this->assertInstanceOf($driverClass, $driver);
+        $driver = (new DriverFactory())->__invoke($container->reveal());
+        $this->assertInstanceOf(FileDriver::class, $driver);
         $this->assertSame($extension, $driver->getLocator()->getFileExtension());
     }
 
@@ -104,6 +106,7 @@ class DriverFactoryTest extends TestCase
         $factory = new DriverFactory();
 
         $driver = $factory($container->reveal());
+        $this->assertInstanceOf(MappingDriverChain::class, $driver);
         $this->assertInstanceOf(TestAsset\StubFileDriver::class, $driver->getDefaultDriver());
     }
 }

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -50,8 +50,7 @@ class DriverFactoryTest extends TestCase
     }
 
     /**
-     * @param string|class-string $driverClass
-     *
+     * @psalm-param string|class-string<FileDriver> $driverClass
      * @dataProvider simplifiedDriverClassProvider
      */
     public function testItSupportsSettingExtensionInDriversUsingSymfonyFileLocator(string $driverClass) : void

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -169,10 +169,8 @@ class EventManagerFactoryTest extends TestCase
 
     /**
      * @param mixed $subscriber
-     *
-     * @return ContainerInterface|ObjectProphecy
      */
-    private function buildContainer($subscriber)
+    private function buildContainer($subscriber) : ObjectProphecy
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('config')->willReturn(true);
@@ -191,10 +189,8 @@ class EventManagerFactoryTest extends TestCase
 
     /**
      * @param mixed $listener
-     *
-     * @return ContainerInterface|ObjectProphecy
      */
-    private function buildContainerWithListener($listener)
+    private function buildContainerWithListener($listener) : ObjectProphecy
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('config')->willReturn(true);

--- a/test/TestAsset/StubFactory.php
+++ b/test/TestAsset/StubFactory.php
@@ -12,15 +12,16 @@ class StubFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function createWithConfig(ContainerInterface $container, $configKey)
+    protected function createWithConfig(ContainerInterface $container, string $configKey)
     {
         return $configKey;
     }
 
+    // phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+
     /**
      * {@inheritdoc}
      */
-    // phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
     public function retrieveConfig(ContainerInterface $container, string $configKey, string $section) : array
     {
         return parent::retrieveConfig($container, $configKey, $section);
@@ -31,7 +32,7 @@ class StubFactory extends AbstractFactory
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultConfig($configKey) : array
+    protected function getDefaultConfig(string $configKey) : array
     {
         return [];
     }

--- a/test/TestAsset/StubFileDriver.php
+++ b/test/TestAsset/StubFileDriver.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace RoaveTest\PsrContainerDoctrine\TestAsset;
 
-use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\FileDriver;
 
 class StubFileDriver extends FileDriver
 {
-    // Disable these sniffs, since we can't control inheritance
-    // phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
-    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint
+    /**
+     * {@inheritdoc}
+     */
     protected function loadMappingFile($file)
     {
         return [];
     }
 
+    /**
+     * @param string|class-string $className
+     */
     public function loadMetadataForClass($className, ClassMetadata $metadata) : void
     {
     }
-
-    // phpcs:enable
 }

--- a/test/TestAsset/StubFileDriver.php
+++ b/test/TestAsset/StubFileDriver.php
@@ -12,7 +12,7 @@ class StubFileDriver extends FileDriver
     /**
      * {@inheritdoc}
      */
-    protected function loadMappingFile($file)
+    protected function loadMappingFile($file) : array
     {
         return [];
     }


### PR DESCRIPTION
This PR reduces the amount of issues found by static analyzers as mentioned in #2  

 - Currently no issues reported by code sniffer
 - Issues found by pslam reduced from **64** to **13**

Some of the remaning psalm issues requires a bit more effort and understanding to clean up. Even I am not sure about the current BC policy related to migration of the repository itself and minimum php version change in composer.json, I went a bit further in some places. For eg:

 - `XcacheCache` is deprecated, dropped the support
 - `MemcacheCache` was deprecated as well, about 2 years ago.
 - Replaced a few deprecated `OutOfBoundsException` usages from `Doctrine\Common\Proxy` namespace with `OutOfBoundsException` from the library.
 - Moved some imports from `Doctrine\Common\Persistence\` to `Doctrine\Persistence\` as they aliased to their new targets at `Common` side.

I can rollback all or some of BC breaks of course, if goal is preserving compatibility as is even after migration.

IMO some tests are needs to be hardened, for eg, no failures after dropping support for `XcacheCache` and `MemcacheCache`. But this could be achived in another PR.

I would like to get some feedback to improve the changes further, if its needed.