### PR TITLE
Simplify driver class check

### DIFF
--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -40,7 +40,7 @@ final class DriverFactory extends AbstractFactory
             $config['paths'] = [$config['paths']];
         }
 
-        if ($config['class'] === AnnotationDriver::class || is_subclass_of($config['class'], AnnotationDriver::class)) {
+        if (is_subclass_of($config['class'], AnnotationDriver::class)) {
             $this->registerAnnotationLoader();
 
             /** @psalm-suppress UndefinedClass */


### PR DESCRIPTION
This change was lost as @asgrim reverted one of the commits in previous PR.

`AnnotationDriver` is abstract, there is no way to instantiate it.