### PR TITLE
Replace Prophecy mocks with PHPUnit mocks enhancement

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -26,6 +26,14 @@
                 <referencedMethod name="Roave\PsrContainerDoctrine\AbstractFactory::retrieveConfig"/>
                 <referencedMethod name="Roave\PsrContainerDoctrine\AbstractFactory::__callStatic"/>
                 <referencedMethod name="Roave\PsrContainerDoctrine\AbstractFactory::__invoke"/>
+
+                <!-- InvocationMocker is still internal. See https://github.com/sebastianbergmann/phpunit/issues/3742 -->
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn" />
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method" />
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturnOnConsecutiveCalls" />
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with" />
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::will" />
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive" />
             </errorLevel>
         </InternalMethod>
         <InternalClass>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -34,6 +34,7 @@
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with" />
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::will" />
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive" />
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturnCallback" />
             </errorLevel>
         </InternalMethod>
         <InternalClass>

--- a/test/AbstractFactoryTest.php
+++ b/test/AbstractFactoryTest.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
 use Roave\PsrContainerDoctrine\Exception\DomainException;
 use RoaveTest\PsrContainerDoctrine\TestAsset\StubFactory;
 
-class AbstractFactoryTest extends TestCase
+final class AbstractFactoryTest extends TestCase
 {
     public function testDefaultConfigKey() : void
     {

--- a/test/AbstractFactoryTest.php
+++ b/test/AbstractFactoryTest.php
@@ -13,21 +13,21 @@ final class AbstractFactoryTest extends TestCase
 {
     public function testDefaultConfigKey() : void
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->createMock(ContainerInterface::class);
         $factory   = new StubFactory();
         $this->assertSame('orm_default', $factory($container));
     }
 
     public function testCustomConfigKey() : void
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->createMock(ContainerInterface::class);
         $factory   = new StubFactory('orm_other');
         $this->assertSame('orm_other', $factory($container));
     }
 
     public function testStaticCall() : void
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->createMock(ContainerInterface::class);
         $this->assertSame('orm_other', StubFactory::orm_other($container));
     }
 
@@ -46,19 +46,18 @@ final class AbstractFactoryTest extends TestCase
      */
     public function testRetrieveConfig(string $configKey, string $section, array $expectedResult, ?array $config = null) : void
     {
-        $container = $this->prophesize(ContainerInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
 
         if ($config === null) {
-            $container->has('config')->willReturn(false);
+            $container->expects($this->once())->method('has')->with('config')->willReturn(false);
         } else {
-            $container->has('config')->willReturn(true);
-            $container->get('config')->willReturn($config);
+            $container->expects($this->once())->method('has')->with('config')->willReturn(true);
+            $container->expects($this->once())->method('get')->with('config')->willReturn($config);
         }
 
-        $factory = new StubFactory();
-        $result  = $factory->retrieveConfig($container->reveal(), $configKey, $section);
+        $actualResult = (new StubFactory())->retrieveConfig($container, $configKey, $section);
 
-        $this->assertSame($expectedResult, $result);
+        $this->assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/test/CacheFactoryTest.php
+++ b/test/CacheFactoryTest.php
@@ -41,12 +41,12 @@ class CacheFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn($config);
+        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container->expects($this->once())->method('has')->with('config')->willReturn(true);
+        $container->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $factory       = new CacheFactory('filesystem');
-        $cacheInstance = $factory($container->reveal());
+        $cacheInstance = $factory($container);
 
         $this->assertInstanceOf(FilesystemCache::class, $cacheInstance);
     }
@@ -64,13 +64,14 @@ class CacheFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn($config);
-        $container->has(ArrayCache::class)->willReturn(false);
+        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container->method('has')
+            ->withConsecutive(['config'], ['config'], [ArrayCache::class], ['config'], [ArrayCache::class])
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false);
+        $container->method('get')->with('config')->willReturn($config);
 
         $factory       = new CacheFactory('chain');
-        $cacheInstance = $factory($container->reveal());
+        $cacheInstance = $factory($container);
 
         $this->assertInstanceOf(ChainCache::class, $cacheInstance);
     }

--- a/test/CacheFactoryTest.php
+++ b/test/CacheFactoryTest.php
@@ -41,7 +41,7 @@ class CacheFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())->method('has')->with('config')->willReturn(true);
         $container->expects($this->once())->method('get')->with('config')->willReturn($config);
 
@@ -64,7 +64,7 @@ class CacheFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->method('has')
             ->withConsecutive(['config'], ['config'], [ArrayCache::class], ['config'], [ArrayCache::class])
             ->willReturnOnConsecutiveCalls(true, true, false, true, false);

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -16,7 +16,7 @@ final class DriverFactoryTest extends TestCase
 {
     public function testMissingClassKeyWillReturnOutOfBoundException() : void
     {
-        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $factory   = new DriverFactory();
 
         $this->expectException(OutOfBoundsException::class);
@@ -115,7 +115,7 @@ final class DriverFactoryTest extends TestCase
      */
     private function createContainerMockWithConfig(array $config, int $expectedCalls = 1) : ContainerInterface
     {
-        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly($expectedCalls))->method('has')->with('config')->willReturn(true);
         $container->expects($this->exactly($expectedCalls))->method('get')->with('config')->willReturn($config);
 

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -12,39 +12,37 @@ use Psr\Container\ContainerInterface;
 use Roave\PsrContainerDoctrine\DriverFactory;
 use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
 
-class DriverFactoryTest extends TestCase
+final class DriverFactoryTest extends TestCase
 {
     public function testMissingClassKeyWillReturnOutOfBoundException() : void
     {
-        $container = $this->prophesize(ContainerInterface::class);
+        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $factory   = new DriverFactory();
 
         $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Missing "class" config key');
 
-        $factory($container->reveal());
+        $factory($container);
     }
 
     public function testItSupportsGlobalBasenameOptionOnFileDrivers() : void
     {
         $globalBasename = 'foobar';
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn([
-            'doctrine' => [
-                'driver' => [
-                    'orm_default' => [
-                        'class' => TestAsset\StubFileDriver::class,
-                        'global_basename' => $globalBasename,
+        $container = $this->createContainerMockWithConfig(
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'orm_default' => [
+                            'class' => TestAsset\StubFileDriver::class,
+                            'global_basename' => $globalBasename,
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]
+        );
 
-        $factory = new DriverFactory();
-
-        $driver = $factory($container->reveal());
+        $driver = (new DriverFactory())->__invoke($container);
         $this->assertInstanceOf(FileDriver::class, $driver);
         $this->assertSame($globalBasename, $driver->getGlobalBasename());
     }
@@ -57,20 +55,20 @@ class DriverFactoryTest extends TestCase
     {
         $extension = '.foo.bar';
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn([
-            'doctrine' => [
-                'driver' => [
-                    'orm_default' => [
-                        'class' => $driverClass,
-                        'extension' => $extension,
+        $container = $this->createContainerMockWithConfig(
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'orm_default' => [
+                            'class' => $driverClass,
+                            'extension' => $extension,
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]
+        );
 
-        $driver = (new DriverFactory())->__invoke($container->reveal());
+        $driver = (new DriverFactory())->__invoke($container);
         $this->assertInstanceOf(FileDriver::class, $driver);
         $this->assertSame($extension, $driver->getLocator()->getFileExtension());
     }
@@ -90,26 +88,37 @@ class DriverFactoryTest extends TestCase
 
     public function testItSupportsSettingDefaultDriverUsingMappingDriverChain() : void
     {
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn([
-            'doctrine' => [
-                'driver' => [
-                    'orm_default' => [
-                        'class' => MappingDriverChain::class,
-                        'default_driver' => 'orm_stub',
-                    ],
-                    'orm_stub' => [
-                        'class' => TestAsset\StubFileDriver::class,
+        $container = $this->createContainerMockWithConfig(
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'orm_default' => [
+                            'class' => MappingDriverChain::class,
+                            'default_driver' => 'orm_stub',
+                        ],
+                        'orm_stub' => [
+                            'class' => TestAsset\StubFileDriver::class,
+                        ],
                     ],
                 ],
             ],
-        ]);
+            2
+        );
 
-        $factory = new DriverFactory();
-
-        $driver = $factory($container->reveal());
+        $driver = (new DriverFactory())->__invoke($container);
         $this->assertInstanceOf(MappingDriverChain::class, $driver);
         $this->assertInstanceOf(TestAsset\StubFileDriver::class, $driver->getDefaultDriver());
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createContainerMockWithConfig(array $config, int $expectedCalls = 1) : ContainerInterface
+    {
+        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $container->expects($this->exactly($expectedCalls))->method('has')->with('config')->willReturn(true);
+        $container->expects($this->exactly($expectedCalls))->method('get')->with('config')->willReturn($config);
+
+        return $container;
     }
 }

--- a/test/EntityManagerFactoryTest.php
+++ b/test/EntityManagerFactoryTest.php
@@ -26,7 +26,7 @@ final class EntityManagerFactoryTest extends TestCase
         $connection    = $this->buildConnection();
         $configuration = $this->buildConfiguration();
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(3))
             ->method('has')
             ->withConsecutive(['config'], ['doctrine.connection.orm_default'], ['doctrine.configuration.orm_default'])
@@ -49,7 +49,7 @@ final class EntityManagerFactoryTest extends TestCase
         $connection    = $this->buildConnection();
         $configuration = $this->buildConfiguration();
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(3))
             ->method('has')
             ->withConsecutive(['config'], ['doctrine.connection.orm_other'], ['doctrine.configuration.orm_other'])
@@ -81,7 +81,7 @@ final class EntityManagerFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(3))
             ->method('has')
             ->withConsecutive(['config'], ['doctrine.connection.orm_foo'], ['doctrine.configuration.orm_bar'])
@@ -98,6 +98,9 @@ final class EntityManagerFactoryTest extends TestCase
         $this->assertSame($configuration, $entityManager->getConfiguration());
     }
 
+    /**
+     * @psalm-return Connection&\PHPUnit\Framework\MockObject\MockObject
+     */
     private function buildConnection() : Connection
     {
         $eventManager = $this->createStub(EventManager::class);

--- a/test/EntityManagerFactoryTest.php
+++ b/test/EntityManagerFactoryTest.php
@@ -26,7 +26,7 @@ final class EntityManagerFactoryTest extends TestCase
         $connection    = $this->buildConnection();
         $configuration = $this->buildConfiguration();
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->setMethods(['has', 'get'])->getMock();
+        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
         $container->expects($this->exactly(3))
             ->method('has')
             ->withConsecutive(['config'], ['doctrine.connection.orm_default'], ['doctrine.configuration.orm_default'])
@@ -49,7 +49,7 @@ final class EntityManagerFactoryTest extends TestCase
         $connection    = $this->buildConnection();
         $configuration = $this->buildConfiguration();
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->setMethods(['has', 'get'])->getMock();
+        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
         $container->expects($this->exactly(3))
             ->method('has')
             ->withConsecutive(['config'], ['doctrine.connection.orm_other'], ['doctrine.configuration.orm_other'])
@@ -81,7 +81,7 @@ final class EntityManagerFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->getMockBuilder(ContainerInterface::class)->setMethods(['has', 'get'])->getMock();
+        $container = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
         $container->expects($this->exactly(3))
             ->method('has')
             ->withConsecutive(['config'], ['doctrine.connection.orm_foo'], ['doctrine.configuration.orm_bar'])
@@ -103,7 +103,7 @@ final class EntityManagerFactoryTest extends TestCase
         $eventManager = $this->createStub(EventManager::class);
         $connection   = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getEventManager'])
+            ->onlyMethods(['getEventManager'])
             ->getMock();
         $connection->method('getEventManager')->willReturn($eventManager);
 

--- a/test/EntityManagerFactoryTest.php
+++ b/test/EntityManagerFactoryTest.php
@@ -98,16 +98,10 @@ final class EntityManagerFactoryTest extends TestCase
         $this->assertSame($configuration, $entityManager->getConfiguration());
     }
 
-    /**
-     * @psalm-return Connection&\PHPUnit\Framework\MockObject\MockObject
-     */
     private function buildConnection() : Connection
     {
-        $eventManager = $this->createStub(EventManager::class);
-        $connection   = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getEventManager'])
-            ->getMock();
+        $eventManager = $this->createMock(EventManager::class);
+        $connection   = $this->createPartialMock(Connection::class, ['getEventManager']);
         $connection->method('getEventManager')->willReturn($eventManager);
 
         return $connection;

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -220,8 +220,6 @@ class EventManagerFactoryTest extends TestCase
 
     /**
      * @param mixed $subscriber
-     *
-     * @pslam-return ContainerInterface&\PHPUnit\Framework\MockObject\MockObject
      */
     private function buildContainer($subscriber) : ContainerInterface
     {

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -109,7 +109,6 @@ class EventManagerFactoryTest extends TestCase
         $eventManager = $factory($container);
         $listeners    = $eventManager->getListeners('foo');
 
-        $this->assertIsArray($listeners);
         $this->assertCount(1, $listeners);
         $this->assertSame($eventSubscriber, array_pop($listeners));
     }
@@ -215,7 +214,6 @@ class EventManagerFactoryTest extends TestCase
         $eventManager = $factory($container);
         $listeners    = $eventManager->getListeners(Events::onFlush);
 
-        $this->assertIsArray($listeners);
         $this->assertCount(1, $listeners);
         $this->assertSame($eventListener, array_pop($listeners));
     }

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -21,7 +21,7 @@ class EventManagerFactoryTest extends TestCase
     public function testDefaults() : void
     {
         $factory      = new EventManagerFactory();
-        $container    = $this->createStub(ContainerInterface::class);
+        $container    = $this->createMock(ContainerInterface::class);
         $eventManager = $factory($container);
 
         $this->assertCount(0, $eventManager->getListeners());
@@ -242,8 +242,6 @@ class EventManagerFactoryTest extends TestCase
 
     /**
      * @param mixed $listener
-     *
-     * @psalm-return ContainerInterface&\PHPUnit\Framework\MockObject\MockObject
      */
     private function buildContainerWithListener($listener) : ContainerInterface
     {

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -49,7 +49,7 @@ class EventManagerFactoryTest extends TestCase
 
     public function testInvalidStringSubscriber() : void
     {
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(2))
             ->method('has')
             ->withConsecutive(['config'], ['NonExistentClass'])
@@ -76,7 +76,7 @@ class EventManagerFactoryTest extends TestCase
 
     public function testClassNameSubscriber() : void
     {
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(2))
             ->method('has')
             ->withConsecutive(['config'], [StubEventSubscriber::class])
@@ -95,7 +95,7 @@ class EventManagerFactoryTest extends TestCase
     {
         $eventSubscriber = new StubEventSubscriber();
 
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(2))
             ->method('has')
             ->withConsecutive(['config'], [StubEventSubscriber::class])
@@ -123,7 +123,7 @@ class EventManagerFactoryTest extends TestCase
 
     public function testInvalidStringListener() : void
     {
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(2))
             ->method('has')
             ->withConsecutive(['config'], ['NonExistentClass'])
@@ -167,7 +167,7 @@ class EventManagerFactoryTest extends TestCase
 
     public function testClassNameListener() : void
     {
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(2))
             ->method('has')
             ->withConsecutive(['config'], [StubEventListener::class])
@@ -193,7 +193,7 @@ class EventManagerFactoryTest extends TestCase
     {
         $eventListener = new StubEventListener();
 
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(2))
             ->method('has')
             ->withConsecutive(['config'], [StubEventListener::class])
@@ -225,7 +225,7 @@ class EventManagerFactoryTest extends TestCase
      */
     private function buildContainer($subscriber) : ContainerInterface
     {
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->method('has')->with('config')->willReturn(true);
         $container->method('get')->with('config')->willReturn(
             [
@@ -249,7 +249,7 @@ class EventManagerFactoryTest extends TestCase
      */
     private function buildContainerWithListener($listener) : ContainerInterface
     {
-        $container = $this->createContainerMock();
+        $container = $this->createMock(ContainerInterface::class);
         $container->method('has')->with('config')->willReturn(true);
         $container->method('get')->with('config')->willReturn($this->getConfigForListener($listener));
 
@@ -290,13 +290,5 @@ class EventManagerFactoryTest extends TestCase
                 ],
             ],
         ];
-    }
-
-    /**
-     * @psalm-return ContainerInterface&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private function createContainerMock() : ContainerInterface
-    {
-        return $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['has', 'get'])->getMock();
     }
 }


### PR DESCRIPTION
This PR moves mocks and stubs across all tests from Prophecy to PHPUnit and addresses issue #8 

Phpcs reporting no errors, tests are green but a few issues on psalm side. I need some assistance to be able to understand why pslam is still unhappy for eg even after introducing special return type hint `@psalm-return ClassA&ClassB` with a native return type declaration for `ClassA` on method body.