### PR TITLE
Increase test coverage + a few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 
 before_install:
   - composer self-update
+  - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:
   - travis_retry composer update --no-interaction

--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -80,8 +80,7 @@ abstract class AbstractFactory
     protected function retrieveConfig(ContainerInterface $container, string $configKey, string $section) : array
     {
         $applicationConfig = $container->has('config') ? $container->get('config') : [];
-        $doctrineConfig    = array_key_exists('doctrine', $applicationConfig) ? $applicationConfig['doctrine'] : [];
-        $sectionConfig     = array_key_exists($section, $doctrineConfig) ? $doctrineConfig[$section] : [];
+        $sectionConfig     = $applicationConfig['doctrine'][$section] ?? [];
 
         if (array_key_exists($configKey, $sectionConfig)) {
             return $sectionConfig[$configKey] + $this->getDefaultConfig($configKey);

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -148,8 +148,8 @@ final class CacheFactory extends AbstractFactory
                     'namespace' => 'psr-container-doctrine',
                     'providers' => [],
                 ];
+            default:
+                return [];
         }
-
-        return [];
     }
 }

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -37,7 +37,7 @@ final class CacheFactory extends AbstractFactory
         $config = $this->retrieveConfig($container, $configKey, 'cache');
 
         if (! array_key_exists('class', $config)) {
-            throw new OutOfBoundsException('Missing "class" config key');
+            throw OutOfBoundsException::forMissingConfigKey('class');
         }
 
         $instance = null;

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Driver\PDOMySql\Driver as PdoMysqlDriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 use Psr\Container\ContainerInterface;
-use function array_key_exists;
 use function is_string;
 
 /**
@@ -93,8 +92,7 @@ final class ConnectionFactory extends AbstractFactory
         }
 
         $applicationConfig        = $container->has('config') ? $container->get('config') : [];
-        $doctrineConfig           = array_key_exists('doctrine', $applicationConfig) ? $applicationConfig['doctrine'] : [];
-        $typesConfig              = array_key_exists('types', $doctrineConfig) ? $doctrineConfig['types'] : [];
+        $typesConfig              = $applicationConfig['doctrine']['types'] ?? [];
         self::$areTypesRegistered = true;
 
         foreach ($typesConfig as $name => $className) {

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -33,7 +33,7 @@ final class DriverFactory extends AbstractFactory
         $config = $this->retrieveConfig($container, $configKey, 'driver');
 
         if (! array_key_exists('class', $config)) {
-            throw new OutOfBoundsException('Missing "class" config key');
+            throw OutOfBoundsException::forMissingConfigKey('class');
         }
 
         if (! is_array($config['paths'])) {

--- a/src/EventManagerFactory.php
+++ b/src/EventManagerFactory.php
@@ -16,7 +16,6 @@ use function is_array;
 use function is_object;
 use function is_string;
 use function method_exists;
-use function sprintf;
 
 /**
  * @method EventManager __invoke(ContainerInterface $container)
@@ -47,12 +46,7 @@ final class EventManagerFactory extends AbstractFactory
             }
 
             if (! $subscriber instanceof EventSubscriber) {
-                throw new DomainException(sprintf(
-                    'Invalid event subscriber "%s" given, mut be a dependency name, class name or an instance'
-                    . ' implementing %s',
-                    $subscriberName,
-                    EventSubscriber::class
-                ));
+                throw DomainException::forInvalidEventSubscriber($subscriberName);
             }
 
             $eventManager->addEventSubscriber($subscriber);
@@ -60,10 +54,7 @@ final class EventManagerFactory extends AbstractFactory
 
         foreach ($config['listeners'] as $listenerConfig) {
             if (! is_array($listenerConfig)) {
-                throw new InvalidArgumentException(sprintf(
-                    'Invalid event listener config: must be an array, "%s" given',
-                    gettype($listenerConfig)
-                ));
+                throw InvalidArgumentException::forInvalidEventListenerConfig($listenerConfig);
             }
 
             $listener     = $listenerConfig['listener'];
@@ -81,19 +72,12 @@ final class EventManagerFactory extends AbstractFactory
             }
 
             if (! is_object($listener)) {
-                throw new DomainException(sprintf(
-                    'Invalid event listener "%s" given, must be a dependency name, class name or an object',
-                    $listenerName
-                ));
+                throw DomainException::forInvalidListener($listenerName);
             }
 
             foreach ((array) $listenerConfig['events'] as $event) {
                 if (! method_exists($listener, $event)) {
-                    throw new DomainException(sprintf(
-                        'Invalid event listener "%s" given: must have a "%s" method',
-                        $listenerName,
-                        $event
-                    ));
+                    throw DomainException::forMissingMethodOnListener($listenerName, $event);
                 }
             }
 

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -4,6 +4,40 @@ declare(strict_types=1);
 
 namespace Roave\PsrContainerDoctrine\Exception;
 
-class DomainException extends \DomainException implements ExceptionInterface
+use Doctrine\Common\EventSubscriber;
+use function sprintf;
+
+final class DomainException extends \DomainException implements ExceptionInterface
 {
+    public static function forMissingMethodOnListener(string $listenerName, string $event) : self
+    {
+        return new self(
+            sprintf(
+                'Invalid event listener "%s" given: must have a "%s" method',
+                $listenerName,
+                $event
+            )
+        );
+    }
+
+    public static function forInvalidListener(string $listenerName) : self
+    {
+        return new self(
+            sprintf(
+                'Invalid event listener "%s" given, must be a dependency name, class name or an object',
+                $listenerName
+            )
+        );
+    }
+
+    public static function forInvalidEventSubscriber(string $subscriberName) : self
+    {
+        return new self(
+            sprintf(
+                'Invalid event subscriber "%s" given, must be a dependency name, class name or an instance implementing %s',
+                $subscriberName,
+                EventSubscriber::class
+            )
+        );
+    }
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,6 +4,21 @@ declare(strict_types=1);
 
 namespace Roave\PsrContainerDoctrine\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+use function gettype;
+use function sprintf;
+
+final class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
+    /**
+     * @param mixed $listenerConfig
+     */
+    public static function forInvalidEventListenerConfig($listenerConfig) : self
+    {
+        return new self(
+            sprintf(
+                'Invalid event listener config: must be an array, "%s" given',
+                gettype($listenerConfig)
+            )
+        );
+    }
 }

--- a/src/Exception/OutOfBoundsException.php
+++ b/src/Exception/OutOfBoundsException.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Roave\PsrContainerDoctrine\Exception;
 
-class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
+use function sprintf;
+
+final class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
 {
+    public static function forMissingConfigKey(string $key) : self
+    {
+        return new self(sprintf('Missing "%s" config key', $key));
+    }
 }

--- a/test/CacheFactoryTest.php
+++ b/test/CacheFactoryTest.php
@@ -7,15 +7,18 @@ namespace RoaveTest\PsrContainerDoctrine;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\ChainCache;
 use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Common\Cache\MemcachedCache;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Roave\PsrContainerDoctrine\AbstractFactory;
 use Roave\PsrContainerDoctrine\CacheFactory;
+use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
+use function extension_loaded;
 
 /**
  * @coversDefaultClass \Roave\PsrContainerDoctrine\CacheFactory
  */
-class CacheFactoryTest extends TestCase
+final class CacheFactoryTest extends TestCase
 {
     /**
      * @covers ::__construct
@@ -30,20 +33,18 @@ class CacheFactoryTest extends TestCase
      */
     public function testFileSystemCacheConstructor() : void
     {
-        $config = [
-            'doctrine' => [
-                'cache' => [
-                    'filesystem' => [
-                        'class'     => FilesystemCache::class,
-                        'directory' => 'test',
+        $container = $this->createContainerMockWithConfig(
+            [
+                'doctrine' => [
+                    'cache' => [
+                        'filesystem' => [
+                            'class' => FilesystemCache::class,
+                            'directory' => 'test',
+                        ],
                     ],
                 ],
-            ],
-        ];
-
-        $container = $this->createMock(ContainerInterface::class);
-        $container->expects($this->once())->method('has')->with('config')->willReturn(true);
-        $container->expects($this->once())->method('get')->with('config')->willReturn($config);
+            ]
+        );
 
         $factory       = new CacheFactory('filesystem');
         $cacheInstance = $factory($container);
@@ -74,5 +75,68 @@ class CacheFactoryTest extends TestCase
         $cacheInstance = $factory($container);
 
         $this->assertInstanceOf(ChainCache::class, $cacheInstance);
+    }
+
+    public function testCanInjectWrappedInstances() : void
+    {
+        if (! extension_loaded('memcached')) {
+            $this->markTestSkipped('Extension memcached is not loaded');
+        }
+
+        /** @psalm-suppress ArgumentTypeCoercion \Memcached needs to be imported otherwise */
+        $wrappedMemcached = $this->createMock('Memcached');
+
+        $config = [
+            'doctrine' => [
+                'cache' => [
+                    'memcached' => [
+                        'class'     => MemcachedCache::class,
+                        'instance'  => $wrappedMemcached,
+                        'namespace' => 'foo',
+                    ],
+                ],
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')
+            ->withConsecutive(['config'], [MemcachedCache::class])
+            ->willReturnOnConsecutiveCalls(true, false);
+        $container->expects($this->once())->method('get')->with('config')->willReturn($config);
+
+        $factory  = new CacheFactory('memcached');
+        $instance = $factory($container);
+
+        $this->assertInstanceOf(MemcachedCache::class, $instance);
+        $this->assertSame($wrappedMemcached, $instance->getMemcached());
+        $this->assertSame('foo', $instance->getNamespace());
+    }
+
+    public function testThrowsForMissingConfigKey() : void
+    {
+        $container = $this->createContainerMockWithConfig(
+            [
+                'doctrine' => [
+                    'cache' => [],
+                ],
+            ]
+        );
+
+        $factory = new CacheFactory('foo');
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Missing "class" config key');
+        $factory($container);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createContainerMockWithConfig(array $config) : ContainerInterface
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())->method('has')->with('config')->willReturn(true);
+        $container->expects($this->once())->method('get')->with('config')->willReturn($config);
+
+        return $container;
     }
 }

--- a/test/ConnectionFactoryTest.php
+++ b/test/ConnectionFactoryTest.php
@@ -19,7 +19,7 @@ use Roave\PsrContainerDoctrine\ConnectionFactory;
 use function defined;
 use function sprintf;
 
-class ConnectionFactoryTest extends TestCase
+final class ConnectionFactoryTest extends TestCase
 {
     /** @var Configuration */
     private $configuration;

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -16,7 +16,7 @@ use stdClass;
 use function array_pop;
 use function sprintf;
 
-class EventManagerFactoryTest extends TestCase
+final class EventManagerFactoryTest extends TestCase
 {
     public function testDefaults() : void
     {


### PR DESCRIPTION
This PR increase coverage of `CacheFactoryTest` with a few more additional improvements.

Notable changes are:
 - Test behavior with wrapped instances (`Memcached` only, `Predis` could be also introduced in same way)
 - Marked all exceptions from library namepace as `final`, introduced named constructors whenever possible.
 - Reduced `array_key_exists` calls and variable assignments in a few places. (Performance++)
 - Some of the tests were marked as `final` previously, remaining ones marked as well for consistency.