### PR TITLE
Make sure `MappingDriverChain` is still instantiated without a default driver if not configured

### DIFF
--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -68,7 +68,7 @@ final class DriverFactory extends AbstractFactory
         }
 
         if ($driver instanceof MappingDriverChain) {
-            if ($config['default_driver'] !== null) {
+            if (array_key_exists('default_driver', $config) && $config['default_driver'] !== null) {
                 $driver->setDefaultDriver($this->createWithConfig($container, $config['default_driver']));
             }
 

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -86,6 +86,26 @@ final class DriverFactoryTest extends TestCase
         ];
     }
 
+    public function testMappingDriverChainIsCreatedWithNoDefaultDriverWhenDefaultDriverNotSpecified() : void
+    {
+        $container = $this->createContainerMockWithConfig(
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'orm_default' => [
+                            'class' => MappingDriverChain::class,
+                        ],
+                    ],
+                ],
+            ],
+            1
+        );
+
+        $driver = (new DriverFactory())->__invoke($container);
+        self::assertInstanceOf(MappingDriverChain::class, $driver);
+        self::assertNull($driver->getDefaultDriver());
+    }
+
     public function testItSupportsSettingDefaultDriverUsingMappingDriverChain() : void
     {
         $container = $this->createContainerMockWithConfig(


### PR DESCRIPTION
Fixes #17 