### PR TITLE
A better fix for #17 : missing default_driver key in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ $ composer require roave/psr-container-doctrine
 In the general case where you are only using a single connection, it's enough to define the entity manager factory:
 
 ```php
-```php
 return [
     'dependencies' => [
         'factories' => [
@@ -37,7 +36,6 @@ return [
 If you want to add a second connection, or use another name than "orm_default", you can do so by using the static
 variants of the factories:
 
-```php
 ```php
 return [
     'dependencies' => [

--- a/example/full-config.php
+++ b/example/full-config.php
@@ -84,6 +84,7 @@ return [
                 'extension' => null,
                 'drivers' => [],
                 'global_basename' => null,
+                'default_driver' => null,
             ],
         ],
         'cache' => [

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -68,7 +68,7 @@ final class DriverFactory extends AbstractFactory
         }
 
         if ($driver instanceof MappingDriverChain) {
-            if (array_key_exists('default_driver', $config) && $config['default_driver'] !== null) {
+            if ($config['default_driver'] !== null) {
                 $driver->setDefaultDriver($this->createWithConfig($container, $config['default_driver']));
             }
 
@@ -93,6 +93,7 @@ final class DriverFactory extends AbstractFactory
             'paths' => [],
             'extension' => null,
             'drivers' => [],
+            'default_driver' => null,
         ];
     }
 


### PR DESCRIPTION
I also hit the problem described with #17 today and wanted to propose this corrective patch to avoid additional array key check on runtime.

Unfortunately the change proposed at https://github.com/DASPRiD/container-interop-doctrine/pull/41/files missed the merge step with default configration in AbstractFactory. The final config we're dealing with there, already passed through and merged with default configuration at `AbstractFactory::retrieveConfig` as below:

```php
if (array_key_exists($configKey, $sectionConfig)) {
    return $sectionConfig[$configKey] + $this->getDefaultConfig($configKey);
} 

return $this->getDefaultConfig($configKey);
```
I also updated `example/full-config.php` to make the key visible there as well:

```php
'driver' => [
    'orm_default' => [
        'class' => null,
        'paths' => [],
        'extension' => null,
        'drivers' => [],
        'global_basename' => null,
        'default_driver' => null,
    ],
],
```