### PR TITLE
Declare hard dependency on doctrine/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.4.0",
+        "doctrine/cache": "^1.0",
         "doctrine/common": "^2.6 || ^3.0",
         "doctrine/dbal": "^2.5 || ^3.0",
         "doctrine/migrations": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07ea117eadea7ee3e58b09756ed38e14",
+    "content-hash": "1c2dc884aa444f2d96272efe1a1077bc",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -151,16 +151,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "1.10.2",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "13e3381b25847283a91948d04640543941309727"
+                "reference": "4cf401d14df219fa6f38b671f5493449151c9ad8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/13e3381b25847283a91948d04640543941309727",
-                "reference": "13e3381b25847283a91948d04640543941309727",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/4cf401d14df219fa6f38b671f5493449151c9ad8",
+                "reference": "4cf401d14df219fa6f38b671f5493449151c9ad8",
                 "shasum": ""
             },
             "require": {
@@ -171,20 +171,19 @@
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
-                "doctrine/coding-standard": "^6.0",
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^8.0",
                 "mongodb/mongodb": "^1.1",
-                "phpunit/phpunit": "^7.0",
-                "predis/predis": "~1.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "predis/predis": "~1.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.2 || ^6.0@dev",
+                "symfony/var-exporter": "^4.4 || ^5.2 || ^6.0@dev"
             },
             "suggest": {
                 "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
@@ -231,7 +230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/1.10.x"
+                "source": "https://github.com/doctrine/cache/tree/1.12.1"
             },
             "funding": [
                 {
@@ -247,7 +246,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-07T18:54:01+00:00"
+            "time": "2021-07-17T14:39:21+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -5483,5 +5482,5 @@
         "php": ">=7.4.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -43,5 +43,22 @@
                 <referencedClass name="Roave\PsrContainerDoctrine\AbstractFactory"/>
             </errorLevel>
         </InternalClass>
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <!-- We cannot upgrade to doctrine/dbal v2 easily and need to find an alternative -->
+                <referencedClass name="Doctrine\Common\Cache\ApcuCache"/>
+                <referencedClass name="Doctrine\Common\Cache\ArrayCache"/>
+                <referencedClass name="Doctrine\Common\Cache\Cache"/>
+                <referencedClass name="Doctrine\Common\Cache\CacheProvider"/>
+                <referencedClass name="Doctrine\Common\Cache\ChainCache"/>
+                <referencedClass name="Doctrine\Common\Cache\FilesystemCache"/>
+                <referencedClass name="Doctrine\Common\Cache\MemcachedCache"/>
+                <referencedClass name="Doctrine\Common\Cache\PhpFileCache"/>
+                <referencedClass name="Doctrine\Common\Cache\PredisCache"/>
+                <referencedClass name="Doctrine\Common\Cache\RedisCache"/>
+                <referencedClass name="Doctrine\Common\Cache\WinCacheCache"/>
+                <referencedClass name="Doctrine\Common\Cache\ZendDataCache"/>
+            </errorLevel>
+        </DeprecatedClass>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
This package has a hard dependency on doctrine/cache v1 via `CacheFactory`.
But that dependency was not declared as such, yet it was fullfilled by coincidence
via a transient dependency. And the relatively recent doctrine/cache v2
introduced **a lot** of breaking changes that break not only this package
tests, but also virtually all of dependents of this package.

Fixes #46