### PR TITLE
Added support for `DoctrineProvider` (cache).

### DIFF
--- a/example/full-config.php
+++ b/example/full-config.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Cache\MemcacheCache;
 use Doctrine\Common\Cache\MemcachedCache;
 use Doctrine\Common\Cache\PhpFileCache;
 use Doctrine\Common\Cache\PredisCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\Cache\WinCacheCache;
 use Doctrine\Common\Cache\XcacheCache;
@@ -19,6 +20,7 @@ use Doctrine\DBAL\Driver\PDOMySql\Driver;
 use Doctrine\Migrations\Configuration\Migration\ConfigurationLoader;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\Command;
+use Psr\Cache\CacheItemPoolInterface;
 use Roave\PsrContainerDoctrine\ConfigurationLoaderFactory;
 use Roave\PsrContainerDoctrine\Migrations\CommandFactory;
 use Roave\PsrContainerDoctrine\Migrations\DependencyFactoryFactory;
@@ -125,6 +127,11 @@ return [
             'predis' => [
                 'class' => PredisCache::class,
                 'instance' => 'my_predis_alias',
+                'namespace' => 'psr-container-doctrine',
+            ],
+            'psrcache' => [
+                'class' => DoctrineProvider::class,
+                'instance' => CacheItemPoolInterface::class,
                 'namespace' => 'psr-container-doctrine',
             ],
             'redis' => [

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -21,6 +21,7 @@
                 <referencedMethod name="Doctrine\DBAL\Configuration::setResultCacheImpl"/>
                 <referencedMethod name="Doctrine\DBAL\Configuration::getResultCacheImpl"/>
                 <referencedMethod name="Doctrine\DBAL\Configuration::setSQLLogger"/>
+                <referencedMethod name="Doctrine\Common\Cache\Psr6\DoctrineProvider::getPool"/>
 
                 <!-- We consume AbstractFactory methods in the tests, but namespaces differ so Psalm complains -->
                 <referencedMethod name="Roave\PsrContainerDoctrine\AbstractFactory::retrieveConfig"/>

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -13,9 +13,11 @@ use Doctrine\Common\Cache\FilesystemCache;
 use Doctrine\Common\Cache\MemcachedCache;
 use Doctrine\Common\Cache\PhpFileCache;
 use Doctrine\Common\Cache\PredisCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\Cache\WinCacheCache;
 use Doctrine\Common\Cache\ZendDataCache;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Container\ContainerInterface;
 use Roave\PsrContainerDoctrine\Exception\OutOfBoundsException;
 
@@ -66,6 +68,10 @@ final class CacheFactory extends AbstractFactory
                     is_array($config['providers']) ? $config['providers'] : []
                 );
                 $cache     = new ChainCache($providers);
+                break;
+
+            case DoctrineProvider::class:
+                $cache = DoctrineProvider::wrap($instance ?? $container->get(CacheItemPoolInterface::class));
                 break;
 
             default:
@@ -157,6 +163,13 @@ final class CacheFactory extends AbstractFactory
                     'class' => ChainCache::class,
                     'namespace' => 'psr-container-doctrine',
                     'providers' => [],
+                ];
+
+            case 'psrcache':
+                return [
+                    'class' => DoctrineProvider::class,
+                    'instance' => CacheItemPoolInterface::class,
+                    'namespace' => 'psr-container-doctrine',
                 ];
 
             default:


### PR DESCRIPTION
Added support for `DoctrineProvider` (cache). 
Factory `doctrine/cache` from `psr/cache`.

```php
// config.php

return [
  'doctrine' => [
    'cache' => [
       'psrcache' => [
           'class' => DoctrineProvider::class,
           'instance' => CacheItemPoolInterface::class,  // PSR cache service name.
           'namespace' => 'psr-container-doctrine',
        ],
    ],
  ].
];
```
