### PR TITLE
Convert `phpunit/phpunit` assertion method calls to static calls

### DIFF
--- a/test/AbstractFactoryTest.php
+++ b/test/AbstractFactoryTest.php
@@ -15,20 +15,20 @@ final class AbstractFactoryTest extends TestCase
     {
         $container = $this->createMock(ContainerInterface::class);
         $factory   = new StubFactory();
-        $this->assertSame('orm_default', $factory($container));
+        self::assertSame('orm_default', $factory($container));
     }
 
     public function testCustomConfigKey(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $factory   = new StubFactory('orm_other');
-        $this->assertSame('orm_other', $factory($container));
+        self::assertSame('orm_other', $factory($container));
     }
 
     public function testStaticCall(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $this->assertSame('orm_other', StubFactory::orm_other($container));
+        self::assertSame('orm_other', StubFactory::orm_other($container));
     }
 
     public function testStaticCallWithoutContainer(): void
@@ -57,7 +57,7 @@ final class AbstractFactoryTest extends TestCase
 
         $actualResult = (new StubFactory())->retrieveConfig($container, $configKey, $section);
 
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/test/CacheFactoryTest.php
+++ b/test/CacheFactoryTest.php
@@ -27,7 +27,7 @@ final class CacheFactoryTest extends TestCase
      */
     public function testExtendsAbstractFactory(): void
     {
-        $this->assertInstanceOf(AbstractFactory::class, new CacheFactory());
+        self::assertInstanceOf(AbstractFactory::class, new CacheFactory());
     }
 
     /**
@@ -51,7 +51,7 @@ final class CacheFactoryTest extends TestCase
         $factory       = new CacheFactory('filesystem');
         $cacheInstance = $factory($container);
 
-        $this->assertInstanceOf(FilesystemCache::class, $cacheInstance);
+        self::assertInstanceOf(FilesystemCache::class, $cacheInstance);
     }
 
     public function testCacheChainContainsInitializedProviders(): void
@@ -76,7 +76,7 @@ final class CacheFactoryTest extends TestCase
         $factory       = new CacheFactory('chain');
         $cacheInstance = $factory($container);
 
-        $this->assertInstanceOf(ChainCache::class, $cacheInstance);
+        self::assertInstanceOf(ChainCache::class, $cacheInstance);
     }
 
     public function testCanInjectWrappedInstances(): void
@@ -109,9 +109,9 @@ final class CacheFactoryTest extends TestCase
         $factory  = new CacheFactory('memcached');
         $instance = $factory($container);
 
-        $this->assertInstanceOf(MemcachedCache::class, $instance);
-        $this->assertSame($wrappedMemcached, $instance->getMemcached());
-        $this->assertSame('foo', $instance->getNamespace());
+        self::assertInstanceOf(MemcachedCache::class, $instance);
+        self::assertSame($wrappedMemcached, $instance->getMemcached());
+        self::assertSame('foo', $instance->getNamespace());
     }
 
     public function testThrowsForMissingConfigKey(): void

--- a/test/ConnectionFactoryTest.php
+++ b/test/ConnectionFactoryTest.php
@@ -96,9 +96,9 @@ final class ConnectionFactoryTest extends TestCase
         $factory    = new ConnectionFactory();
         $connection = $factory($this->buildContainer());
 
-        $this->assertSame($this->configuration, $connection->getConfiguration());
-        $this->assertSame($this->eventManger, $connection->getEventManager());
-        $this->assertSame([
+        self::assertSame($this->configuration, $connection->getConfiguration());
+        self::assertSame($this->eventManger, $connection->getEventManager());
+        self::assertSame([
             'driverClass' => PDOSqliteDriver::class,
             'wrapperClass' => null,
             'pdo' => null,
@@ -110,8 +110,8 @@ final class ConnectionFactoryTest extends TestCase
         $factory    = new ConnectionFactory('orm_other');
         $connection = $factory($this->buildContainer('orm_other', 'orm_other', 'orm_other'));
 
-        $this->assertSame($this->configuration, $connection->getConfiguration());
-        $this->assertSame($this->eventManger, $connection->getEventManager());
+        self::assertSame($this->configuration, $connection->getConfiguration());
+        self::assertSame($this->eventManger, $connection->getEventManager());
     }
 
     public function testConfigKeysTakenFromConfig(): void
@@ -122,8 +122,8 @@ final class ConnectionFactoryTest extends TestCase
             'event_manager' => 'orm_bar',
         ]));
 
-        $this->assertSame($this->configuration, $connection->getConfiguration());
-        $this->assertSame($this->eventManger, $connection->getEventManager());
+        self::assertSame($this->configuration, $connection->getConfiguration());
+        self::assertSame($this->eventManger, $connection->getEventManager());
     }
 
     public function testParamsInjection(): void
@@ -133,7 +133,7 @@ final class ConnectionFactoryTest extends TestCase
             'params' => ['username' => 'foo'],
         ]));
 
-        $this->assertSame([
+        self::assertSame([
             'username' => 'foo',
             'driverClass' => PDOSqliteDriver::class,
             'wrapperClass' => null,
@@ -151,7 +151,7 @@ final class ConnectionFactoryTest extends TestCase
             ['doctrine_mapping_types' => ['foo' => 'boolean']]
         ));
 
-        $this->assertTrue($connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('foo'));
+        self::assertTrue($connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('foo'));
     }
 
     public function testCustomTypeDoctrineMappingTypesInjection(): void
@@ -165,7 +165,7 @@ final class ConnectionFactoryTest extends TestCase
             'doctrine_mapping_types' => ['foo' => 'custom_type'],
         ]));
 
-        $this->assertTrue($connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('foo'));
+        self::assertTrue($connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('foo'));
     }
 
     public function testCustomPlatform(): void
@@ -180,7 +180,7 @@ final class ConnectionFactoryTest extends TestCase
 
         $connection = $factory($container);
 
-        $this->assertSame($this->customPlatform, $connection->getDatabasePlatform());
+        self::assertSame($this->customPlatform, $connection->getDatabasePlatform());
     }
 
     /**

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -47,8 +47,8 @@ final class DriverFactoryTest extends TestCase
         );
 
         $driver = (new DriverFactory())->__invoke($container);
-        $this->assertInstanceOf(FileDriver::class, $driver);
-        $this->assertSame($globalBasename, $driver->getGlobalBasename());
+        self::assertInstanceOf(FileDriver::class, $driver);
+        self::assertSame($globalBasename, $driver->getGlobalBasename());
     }
 
     /**
@@ -73,8 +73,8 @@ final class DriverFactoryTest extends TestCase
         );
 
         $driver = (new DriverFactory())->__invoke($container);
-        $this->assertInstanceOf(FileDriver::class, $driver);
-        $this->assertSame($extension, $driver->getLocator()->getFileExtension());
+        self::assertInstanceOf(FileDriver::class, $driver);
+        self::assertSame($extension, $driver->getLocator()->getFileExtension());
     }
 
     /**
@@ -130,8 +130,8 @@ final class DriverFactoryTest extends TestCase
         );
 
         $driver = (new DriverFactory())->__invoke($container);
-        $this->assertInstanceOf(MappingDriverChain::class, $driver);
-        $this->assertInstanceOf(TestAsset\StubFileDriver::class, $driver->getDefaultDriver());
+        self::assertInstanceOf(MappingDriverChain::class, $driver);
+        self::assertInstanceOf(TestAsset\StubFileDriver::class, $driver->getDefaultDriver());
     }
 
     /**
@@ -182,7 +182,7 @@ final class DriverFactoryTest extends TestCase
         );
 
         $driver = (new DriverFactory())->__invoke($container);
-        $this->assertInstanceOf($driverClass, $driver);
+        self::assertInstanceOf($driverClass, $driver);
     }
 
     /**

--- a/test/EntityManagerFactoryTest.php
+++ b/test/EntityManagerFactoryTest.php
@@ -19,7 +19,7 @@ final class EntityManagerFactoryTest extends TestCase
 {
     public function testExtendsAbstractFactory(): void
     {
-        $this->assertInstanceOf(AbstractFactory::class, new EntityManagerFactory());
+        self::assertInstanceOf(AbstractFactory::class, new EntityManagerFactory());
     }
 
     public function testDefaults(): void
@@ -41,8 +41,8 @@ final class EntityManagerFactoryTest extends TestCase
         $factory       = new EntityManagerFactory();
         $entityManager = $factory($container);
 
-        $this->assertSame($connection, $entityManager->getConnection());
-        $this->assertSame($configuration, $entityManager->getConfiguration());
+        self::assertSame($connection, $entityManager->getConnection());
+        self::assertSame($configuration, $entityManager->getConfiguration());
     }
 
     public function testConfigKeyTakenFromSelf(): void
@@ -63,8 +63,8 @@ final class EntityManagerFactoryTest extends TestCase
         $factory       = new EntityManagerFactory('orm_other');
         $entityManager = $factory($container);
 
-        $this->assertSame($connection, $entityManager->getConnection());
-        $this->assertSame($configuration, $entityManager->getConfiguration());
+        self::assertSame($connection, $entityManager->getConnection());
+        self::assertSame($configuration, $entityManager->getConfiguration());
     }
 
     public function testConfigKeyTakenFromConfig(): void
@@ -95,8 +95,8 @@ final class EntityManagerFactoryTest extends TestCase
         $factory       = new EntityManagerFactory();
         $entityManager = $factory($container);
 
-        $this->assertSame($connection, $entityManager->getConnection());
-        $this->assertSame($configuration, $entityManager->getConfiguration());
+        self::assertSame($connection, $entityManager->getConnection());
+        self::assertSame($configuration, $entityManager->getConfiguration());
     }
 
     private function buildConnection(): Connection

--- a/test/EventManagerFactoryTest.php
+++ b/test/EventManagerFactoryTest.php
@@ -25,7 +25,7 @@ final class EventManagerFactoryTest extends TestCase
         $container    = $this->createMock(ContainerInterface::class);
         $eventManager = $factory($container);
 
-        $this->assertCount(0, $eventManager->getListeners());
+        self::assertCount(0, $eventManager->getListeners());
     }
 
     public function testInvalidInstanceSubscriber(): void
@@ -72,7 +72,7 @@ final class EventManagerFactoryTest extends TestCase
         $factory      = new EventManagerFactory();
         $eventManager = $factory($this->buildContainer(new StubEventSubscriber()));
 
-        $this->assertCount(1, $eventManager->getListeners('foo'));
+        self::assertCount(1, $eventManager->getListeners('foo'));
     }
 
     public function testClassNameSubscriber(): void
@@ -89,7 +89,7 @@ final class EventManagerFactoryTest extends TestCase
         $factory      = new EventManagerFactory();
         $eventManager = $factory($container);
 
-        $this->assertCount(1, $eventManager->getListeners('foo'));
+        self::assertCount(1, $eventManager->getListeners('foo'));
     }
 
     public function testServiceNameSubscriber(): void
@@ -110,8 +110,8 @@ final class EventManagerFactoryTest extends TestCase
         $eventManager = $factory($container);
         $listeners    = $eventManager->getListeners('foo');
 
-        $this->assertCount(1, $listeners);
-        $this->assertSame($eventSubscriber, array_pop($listeners));
+        self::assertCount(1, $listeners);
+        self::assertSame($eventSubscriber, array_pop($listeners));
     }
 
     public function testInvalidTypeListener(): void
@@ -163,7 +163,7 @@ final class EventManagerFactoryTest extends TestCase
             'listener' => new StubEventListener(),
         ]));
 
-        $this->assertCount(1, $eventManager->getListeners(Events::onFlush));
+        self::assertCount(1, $eventManager->getListeners(Events::onFlush));
     }
 
     public function testClassNameListener(): void
@@ -187,7 +187,7 @@ final class EventManagerFactoryTest extends TestCase
         $factory      = new EventManagerFactory();
         $eventManager = $factory($container);
 
-        $this->assertCount(1, $eventManager->getListeners(Events::onFlush));
+        self::assertCount(1, $eventManager->getListeners(Events::onFlush));
     }
 
     public function testServiceNameListener(): void
@@ -215,8 +215,8 @@ final class EventManagerFactoryTest extends TestCase
         $eventManager = $factory($container);
         $listeners    = $eventManager->getListeners(Events::onFlush);
 
-        $this->assertCount(1, $listeners);
-        $this->assertSame($eventListener, array_pop($listeners));
+        self::assertCount(1, $listeners);
+        self::assertSame($eventListener, array_pop($listeners));
     }
 
     /**

--- a/test/Migrations/CommandFactoryTest.php
+++ b/test/Migrations/CommandFactoryTest.php
@@ -40,7 +40,7 @@ final class CommandFactoryTest extends TestCase
 
         $factory = new CommandFactory();
         /** @psalm-suppress ArgumentTypeCoercion */
-        $this->assertInstanceOf($commandClass, $factory($container, $commandClass));
+        self::assertInstanceOf($commandClass, $factory($container, $commandClass));
     }
 
     /**
@@ -68,7 +68,7 @@ final class CommandFactoryTest extends TestCase
 
         $factory = new CommandFactory();
         /** @psalm-suppress ArgumentTypeCoercion */
-        $this->assertInstanceOf($commandClass, $factory($container, $commandClass));
+        self::assertInstanceOf($commandClass, $factory($container, $commandClass));
     }
 
     /**

--- a/test/Migrations/ConfigurationLoaderFactoryTest.php
+++ b/test/Migrations/ConfigurationLoaderFactoryTest.php
@@ -25,7 +25,7 @@ final class ConfigurationLoaderFactoryTest extends TestCase
 
     public function testExtendsAbstractFactory(): void
     {
-        $this->assertInstanceOf(AbstractFactory::class, new ConfigurationLoaderFactory());
+        self::assertInstanceOf(AbstractFactory::class, new ConfigurationLoaderFactory());
     }
 
     public function testConfigValues(): void
@@ -66,16 +66,16 @@ final class ConfigurationLoaderFactoryTest extends TestCase
             );
 
         $migrationsConfiguration = (new ConfigurationLoaderFactory())($container);
-        $this->assertInstanceOf(ConfigurationArray::class, $migrationsConfiguration);
+        self::assertInstanceOf(ConfigurationArray::class, $migrationsConfiguration);
         $configuration = $migrationsConfiguration->getConfiguration();
 
-        $this->assertSame(self::ALL_OR_NOTHING, $configuration->isAllOrNothing());
-        $this->assertSame(self::CHECK_PLATFORM, $configuration->isDatabasePlatformChecked());
+        self::assertSame(self::ALL_OR_NOTHING, $configuration->isAllOrNothing());
+        self::assertSame(self::CHECK_PLATFORM, $configuration->isDatabasePlatformChecked());
         $storageConfiguration = $configuration->getMetadataStorageConfiguration();
-        $this->assertNotNull($storageConfiguration);
+        self::assertNotNull($storageConfiguration);
         assert($storageConfiguration instanceof TableMetadataStorageConfiguration);
-        $this->assertSame(self::TABLE, $storageConfiguration->getTableName());
-        $this->assertSame(self::COLUMN, $storageConfiguration->getVersionColumnName());
-        $this->assertSame(self::COLUMN_LENGTH, $storageConfiguration->getVersionColumnLength());
+        self::assertSame(self::TABLE, $storageConfiguration->getTableName());
+        self::assertSame(self::COLUMN, $storageConfiguration->getVersionColumnName());
+        self::assertSame(self::COLUMN_LENGTH, $storageConfiguration->getVersionColumnLength());
     }
 }

--- a/test/Migrations/DependencyFactoryFactoryTest.php
+++ b/test/Migrations/DependencyFactoryFactoryTest.php
@@ -37,8 +37,8 @@ final class DependencyFactoryFactoryTest extends TestCase
 
         $factory           = new DependencyFactoryFactory();
         $dependencyFactory = $factory($container);
-        $this->assertInstanceOf(DependencyFactory::class, $dependencyFactory);
-        $this->assertSame($entityManager, $dependencyFactory->getEntityManager());
-        $this->assertInstanceOf(Configuration::class, $dependencyFactory->getConfiguration());
+        self::assertInstanceOf(DependencyFactory::class, $dependencyFactory);
+        self::assertSame($entityManager, $dependencyFactory->getEntityManager());
+        self::assertInstanceOf(Configuration::class, $dependencyFactory->getConfiguration());
     }
 }


### PR DESCRIPTION
In `phpunit/phpunit`, the `assert*` methods are declared as static.

Since PHP allows static method calls to be called non-static (and vice-versa), thats not a real problem related to the assertion methods but for synchronicity, I prefer having it the right way.