### PR TITLE
Migrations config: remove placeholder defaults to adapt to the new `array_replace_recursive()` config merging semantics

### DIFF
--- a/src/Migrations/ConfigurationLoaderFactory.php
+++ b/src/Migrations/ConfigurationLoaderFactory.php
@@ -37,7 +37,7 @@ class ConfigurationLoaderFactory extends AbstractFactory
                 'executed_at_column_name' => 'executed_at',
                 'execution_time_column_name' => 'execution_time',
             ],
-            'migrations_paths' => ['My\Migrations' => 'scripts/orm/migrations'],
+            'migrations_paths' => [],
             'all_or_nothing' => true,
             'check_database_platform' => true,
         ];

--- a/test/Migrations/ConfigurationLoaderFactoryTest.php
+++ b/test/Migrations/ConfigurationLoaderFactoryTest.php
@@ -77,5 +77,7 @@ final class ConfigurationLoaderFactoryTest extends TestCase
         self::assertSame(self::TABLE, $storageConfiguration->getTableName());
         self::assertSame(self::COLUMN, $storageConfiguration->getVersionColumnName());
         self::assertSame(self::COLUMN_LENGTH, $storageConfiguration->getVersionColumnLength());
+
+        self::assertSame([self::NS => self::DIRECTORY], $configuration->getMigrationDirectories());
     }
 }


### PR DESCRIPTION
Hi, I just updated my deps to `v3.4.0` and https://github.com/Roave/psr-container-doctrine/commit/9cfad0cdd159ac86cd1d5d05759fb0007210b05d (contained in https://github.com/Roave/psr-container-doctrine/pull/63) broke my app.
(Part of) my config is:
```php
    'doctrine' => [
        'migrations' => [
            'orm_default' => [
                'migrations_paths' => [
                    'Our\\Migrations' => '/lib/Migrations',
                ],
            ],
        ],
    ],
```
Previously, the `+` plus operator overrode the whole `migrations_paths` key present in https://github.com/Roave/psr-container-doctrine/blob/e7548e04f4072cafe30bd430444ab5b83167ba06/src/Migrations/ConfigurationLoaderFactory.php#L40 retrieved by `getDefaultConfig`, and the only path present at the end of the configuration factory process was the one of mine.

Now, `array_replace_recursive` **adds** mine to the default one, resulting after merge in:
```php
    'doctrine' => [
        'migrations' => [
            'orm_default' => [
                'migrations_paths' => [
                    'Our\\Migrations' => 'lib/Migrations',
                    'My\\Migrations' => 'scripts/orm/migrations',
                ],
            ],
        ],
    ],
```

But I don't use the default path, so the following exception raises:

```
Doctrine\Migrations\Finder\Exception\InvalidDirectory: Cannot load migrations from "scripts/orm/migrations" because it is not a valid directory

/vendor/doctrine/migrations/lib/Doctrine/Migrations/Finder/Exception/InvalidDirectory.php:15
/vendor/doctrine/migrations/lib/Doctrine/Migrations/Finder/Finder.php:37
/vendor/doctrine/migrations/lib/Doctrine/Migrations/Finder/GlobFinder.php:20
/vendor/doctrine/migrations/lib/Doctrine/Migrations/FilesystemMigrationsRepository.php:147
/vendor/doctrine/migrations/lib/Doctrine/Migrations/FilesystemMigrationsRepository.php:122
/vendor/doctrine/migrations/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php:157
```

Reverting back to the `+` operator doesn't seem a solution to me.
Of course this PR breaks everyone who uses the proposed default config: we should suggest to manually read the row into their config, which is good since explicit config is better.