### PR TITLE
Make the full config example functional

### DIFF
--- a/example/full-config.php
+++ b/example/full-config.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Driver\PDOMySql\Driver;
 use Doctrine\Migrations\Configuration\Migration\ConfigurationLoader;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\Command;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Roave\PsrContainerDoctrine\ConfigurationLoaderFactory;
 use Roave\PsrContainerDoctrine\Migrations\CommandFactory;
 use Roave\PsrContainerDoctrine\Migrations\DependencyFactoryFactory;
@@ -32,7 +34,7 @@ return [
                 'query_cache' => 'array',
                 'hydration_cache' => 'array',
                 'driver' => 'orm_default', // Actually defaults to the configuration config key, not hard-coded
-                'auto_generate_proxy_classes' => true,
+                'generate_proxies' => true,
                 'proxy_dir' => 'data/cache/DoctrineEntityProxy',
                 'proxy_namespace' => 'DoctrineEntityProxy',
                 'entity_namespaces' => [],
@@ -45,9 +47,9 @@ return [
                 'custom_hydration_modes' => [],
                 'naming_strategy' => null,
                 'quote_strategy' => null,
-                'default_repository_class_name' => null,
+                'default_repository_class_name' => EntityRepository::class,
                 'repository_factory' => null,
-                'class_metadata_factory_name' => null,
+                'class_metadata_factory_name' => ClassMetadataFactory::class,
                 'entity_listener_resolver' => null,
                 'second_level_cache' => [
                     'enabled' => false,
@@ -56,24 +58,23 @@ return [
                     'file_lock_region_directory' => '',
                     'regions' => [],
                 ],
-                'sql_logger' => null,
                 'middlewares' => [
                     // List of middlewares doctrine will use to decorate the `Driver` component.
                     // (see https://github.com/doctrine/dbal/blob/3.3.2/docs/en/reference/architecture.rst#middlewares)
-                    'app.foo.middleware', // Will be looked up in the container.
-                    'app.bar.middleware', // Will be looked up in the container.
+                    // 'app.foo.middleware', // Will be looked up in the container.
+                    // 'app.bar.middleware', // Will be looked up in the container.
                 ],
             ],
         ],
         'connection' => [
             'orm_default' => [
                 'driver_class' => Driver::class,
-                'wrapper_class' => null,
+//                'wrapper_class' => null,
                 'pdo' => null,
                 'configuration' => 'orm_default', // Actually defaults to the connection config key, not hard-coded
                 'event_manager' => 'orm_default', // Actually defaults to the connection config key, not hard-coded
                 'params' => [],
-                'doctrine_mapping_types' => [],
+                'doctrine_type_mappings' => [],
                 'doctrine_commented_types' => [],
             ],
         ],
@@ -86,17 +87,16 @@ return [
         'event_manager' => [
             'orm_default' => [
                 'subscribers' => [],
-                'listeners' => [],
             ],
         ],
         'driver' => [
             'orm_default' => [
-                'class' => null,
-                'paths' => [],
+                'class' => AnnotationDriver::class,
+                'paths' => [
+                    __DIR__.'/Entity/', // If this config is is src/App/ConfigProvider.php
+                ],
                 'extension' => null,
                 'drivers' => [],
-                'global_basename' => null,
-                'default_driver' => null,
             ],
         ],
         'cache' => [


### PR DESCRIPTION
Change done:
- Comment `connection` `orm_default` `wrapper_class` as it is not defined
- replace `auto_generate_proxy_classes` by `generate_proxies`
- remove `sql_logger` as it is deprecated and replaced by middlewares
- set the default `default_repository_class_name` otherwise the config don't work
- set the default `class_metadata_factory_name` otherwise the config don't work
- Comment middleware `app.foo.middleware` and `app.bar.middleware`
- Remove `event_manager` `listeners` as no setter exist for it
- Remove `driver` `orm_default` `global_basename` as dont have setter 
- Remove `driver` `orm_default` `default_driver` as dont have setter 
- Set a value for `driver` `orm_default` `class`
- Set a value for `driver` `orm_default` `paths`
- Remove `driver` `orm_default` `default_driver` as it don't have a valid setter
- replace `doctrine_mapping_types` by `doctrine_type_mappings`