### PR TITLE
 [Feature] Define schema assets filter in configuration (continue)

### DIFF
--- a/example/full-config.php
+++ b/example/full-config.php
@@ -63,6 +63,7 @@ return [
                     'app.foo.middleware', // Will be looked up in the container.
                     'app.bar.middleware', // Will be looked up in the container.
                 ],
+                'schema_assets_filter' => null,
             ],
         ],
         'connection' => [

--- a/example/full-config.php
+++ b/example/full-config.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Cache\WinCacheCache;
 use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\Common\Cache\ZendDataCache;
 use Doctrine\DBAL\Driver\PDOMySql\Driver;
+use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\Migrations\Configuration\Migration\ConfigurationLoader;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\Command;
@@ -63,7 +64,7 @@ return [
                     'app.foo.middleware', // Will be looked up in the container.
                     'app.bar.middleware', // Will be looked up in the container.
                 ],
-                'schema_assets_filter' => null,
+                'schema_assets_filter' => 'my_schema_assets_filter',
             ],
         ],
         'connection' => [
@@ -194,6 +195,22 @@ return [
 
             DependencyFactory::class => DependencyFactoryFactory::class,
             ConfigurationLoader::class => ConfigurationLoaderFactory::class,
+
+            'my_schema_assets_filter' => static function (): callable {
+                /**
+                 * Filter out assets (table, sequence) by name from Schema
+                 * because ones have no mapping and this cause unwanted create|drop statements in migration
+                 * generated with migrations:diff command when compare ORM schema and schema introspected from database
+                 */
+                return static fn (AbstractAsset|string $asset): bool => ! in_array(
+                    $asset instanceof AbstractAsset ? $asset->getName() : $asset,
+                    [
+                        'sequence_to_generate_value',
+                        'table_without_doctrine_mapping',
+                    ],
+                    true,
+                );
+            },
         ],
     ],
 ];

--- a/src/ConfigurationFactory.php
+++ b/src/ConfigurationFactory.php
@@ -135,6 +135,12 @@ final class ConfigurationFactory extends AbstractFactory
             $configuration->setEntityListenerResolver($config['entity_listener_resolver']);
         }
 
+        if (is_string($config['schema_assets_filter'])) {
+            $configuration->setSchemaAssetsFilter($container->get($config['schema_assets_filter']));
+        } elseif (is_callable($config['schema_assets_filter'])) {
+            $configuration->setSchemaAssetsFilter($config['schema_assets_filter']);
+        }
+
         if ($config['default_repository_class_name'] !== null) {
             $configuration->setDefaultRepositoryClassName($config['default_repository_class_name']);
         }

--- a/src/ConfigurationFactory.php
+++ b/src/ConfigurationFactory.php
@@ -137,7 +137,7 @@ final class ConfigurationFactory extends AbstractFactory
 
         if (is_string($config['schema_assets_filter'])) {
             $configuration->setSchemaAssetsFilter($container->get($config['schema_assets_filter']));
-        } elseif (is_callable($config['schema_assets_filter'])) {
+        } elseif ($config['schema_assets_filter'] !== null) {
             $configuration->setSchemaAssetsFilter($config['schema_assets_filter']);
         }
 

--- a/src/ConfigurationFactory.php
+++ b/src/ConfigurationFactory.php
@@ -137,8 +137,6 @@ final class ConfigurationFactory extends AbstractFactory
 
         if (is_string($config['schema_assets_filter'])) {
             $configuration->setSchemaAssetsFilter($container->get($config['schema_assets_filter']));
-        } elseif ($config['schema_assets_filter'] !== null) {
-            $configuration->setSchemaAssetsFilter($config['schema_assets_filter']);
         }
 
         if ($config['default_repository_class_name'] !== null) {
@@ -221,6 +219,7 @@ final class ConfigurationFactory extends AbstractFactory
             'repository_factory' => null,
             'class_metadata_factory_name' => null,
             'entity_listener_resolver' => null,
+            'schema_assets_filter' => null,
             'second_level_cache' => [
                 'enabled' => false,
                 'default_lifetime' => 3600,

--- a/test/ConfigurationFactoryTest.php
+++ b/test/ConfigurationFactoryTest.php
@@ -118,6 +118,90 @@ final class ConfigurationFactoryTest extends TestCase
         self::assertSame([$middlewareFoo, $middlewareBar], $configuration->getMiddlewares());
     }
 
+    public function testWillSetSchemaAssetsFilterByContainerId(): void
+    {
+        $testFilter = static fn (): bool => true;
+        $config     = [
+            'doctrine' => [
+                'configuration' => [
+                    'orm_default' => ['schema_assets_filter' => 'testFilterContainerId'],
+                ],
+            ],
+        ];
+
+        $container = $this->createStub(ContainerInterface::class);
+
+        $container
+            ->method('has')
+            ->willReturnCallback(
+                static fn (string $id) => in_array(
+                    $id,
+                    [
+                        'config',
+                        'doctrine.driver.orm_default',
+                        'testFilterContainerId',
+                    ],
+                    true,
+                ),
+            );
+
+        $container
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['config', $config],
+                    ['doctrine.driver.orm_default', $this->createStub(MappingDriver::class)],
+                    ['testFilterContainerId', $testFilter],
+                ],
+            );
+
+        $configuration = (new ConfigurationFactory())($container);
+
+        self::assertSame($testFilter, $configuration->getSchemaAssetsFilter());
+    }
+
+    public function testMistypeInSchemaAssetsFilterResolvedContainerId(): void
+    {
+        $testFilter = ['misconfig' => 'resolved service is not callable'];
+        $config     = [
+            'doctrine' => [
+                'configuration' => [
+                    'orm_default' => ['schema_assets_filter' => 'testFilterContainerId'],
+                ],
+            ],
+        ];
+
+        $container = $this->createStub(ContainerInterface::class);
+
+        $container
+            ->method('has')
+            ->willReturnCallback(
+                static fn (string $id) => in_array(
+                    $id,
+                    [
+                        'config',
+                        'doctrine.driver.orm_default',
+                        'testFilterContainerId',
+                    ],
+                    true,
+                ),
+            );
+
+        $container
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['config', $config],
+                    ['doctrine.driver.orm_default', $this->createStub(MappingDriver::class)],
+                    ['testFilterContainerId', $testFilter],
+                ],
+            );
+
+        self::expectError();
+
+        (new ConfigurationFactory())($container);
+    }
+
     /**
      * @param non-empty-string $propertyName
      *


### PR DESCRIPTION
Continue https://github.com/Roave/psr-container-doctrine/pull/36 on base of 3.10.x branch + unit tests

Add support `doctrine.configuration.{$name}.schema_assets_filter` configuration value 