### PR TITLE
Add default value for typed_field_mapper

### DIFF
--- a/src/ConfigurationFactory.php
+++ b/src/ConfigurationFactory.php
@@ -184,6 +184,7 @@ final class ConfigurationFactory extends AbstractFactory
             'filters' => [],
             'custom_hydration_modes' => [],
             'naming_strategy' => null,
+            'typed_field_mapper' => null,
             'quote_strategy' => null,
             'default_repository_class_name' => null,
             'repository_factory' => null,


### PR DESCRIPTION
I forgot to set a default value in my previous PR, which may have caused warnings.