### PR TITLE
Declare support for DBAL 3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0",
         "doctrine/common": "^3.4.4",
-        "doctrine/dbal": "^4.0.4",
+        "doctrine/dbal": "^3.8.2 || ^4",
         "doctrine/event-manager": "^2.0.1",
         "doctrine/migrations": "^3.8.0",
         "doctrine/orm": "^3.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a08a80f0839d2d4f11be577fe86c65f1",
+    "content-hash": "90c32cc42b81f2ab0101692fe3e78580",
     "packages": [
         {
             "name": "doctrine/collections",

--- a/test/ConfigurationFactoryTest.php
+++ b/test/ConfigurationFactoryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace RoaveTest\PsrContainerDoctrine;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
@@ -211,7 +213,11 @@ final class ConfigurationFactoryTest extends TestCase
             );
 
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('Doctrine\DBAL\Configuration::setSchemaAssetsFilter(): Argument #1 ($schemaAssetsFilter) must be of type callable, array given');
+        if (InstalledVersions::satisfies(new VersionParser(), 'doctrine/dbal', '^3.8')) {
+            $this->expectExceptionMessage('Doctrine\DBAL\Configuration::setSchemaAssetsFilter(): Argument #1 ($callable) must be of type ?callable, array given,');
+        } else {
+            $this->expectExceptionMessage('Doctrine\DBAL\Configuration::setSchemaAssetsFilter(): Argument #1 ($schemaAssetsFilter) must be of type callable, array given');
+        }
 
         (new ConfigurationFactory())($container);
     }


### PR DESCRIPTION
Because the latest doctrine/orm, v3.2, supports DBAL "^3.8.2 || ^4", it would be nice to also support it here, as long as it not too much extra work.

I create this as a draft, because I didn't test in a real projects, but all tests seem  to pass...

Is it something that makes sense to you ?