### PR TITLE
No longer mark AbstractFactory as internal

### DIFF
--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -11,7 +11,6 @@ use function array_replace_recursive;
 use function sprintf;
 
 /**
- * @internal
  *
  * @template T
  */

--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -11,7 +11,6 @@ use function array_replace_recursive;
 use function sprintf;
 
 /**
- *
  * @template T
  */
 abstract class AbstractFactory


### PR DESCRIPTION
If a factory is used and it requires a key other than 'orm_default' you must construct and invoke the factory yourself. Doing so will invoke methods marked as internal, causing tooling to erroneously mark using this factory as invalid. This patch removes the internal annotation, allowing the AbstractFactory to be used to customize the configuration key without triggering internal method usage.

Fixes #139