### PR TITLE
Instantiate ConfigurationLoaderFactory when not in container

### DIFF
--- a/src/Migrations/DependencyFactoryFactory.php
+++ b/src/Migrations/DependencyFactoryFactory.php
@@ -25,8 +25,14 @@ final class DependencyFactoryFactory extends AbstractFactory
             ),
         );
 
+        if ($container->has(ConfigurationLoader::class)) {
+            $configurationLoader = $container->get(ConfigurationLoader::class);
+        } else {
+            $configurationLoader = (new ConfigurationLoaderFactory($configKey))($container);
+        }
+
         return DependencyFactory::fromEntityManager(
-            $container->get(ConfigurationLoader::class),
+            $configurationLoader,
             $entityManagerLoader,
         );
     }

--- a/test/Migrations/CommandFactoryTest.php
+++ b/test/Migrations/CommandFactoryTest.php
@@ -52,16 +52,33 @@ final class CommandFactoryTest extends TestCase
     public function testReturnsCommandWhenContainerHasNoDependencyFactory(string $commandClass): void
     {
         $container = $this->createMock(ContainerInterface::class);
+        $config    = [
+            'doctrine' => [
+                'configuration' => [
+                    'orm_default' => [
+                        'metadata_cache' => 'metadata',
+                        'result_cache' => 'result',
+                        'query_cache' => 'query',
+                        'hydration_cache' => 'hydration',
+                        'second_level_cache' => ['enabled' => true],
+                    ],
+                ],
+            ],
+        ];
+
         $container->method('has')
             ->willReturnMap(
                 [
+                    ['config', true],
                     [DependencyFactory::class, false],
+                    [ConfigurationLoader::class, true],
                     ['doctrine.entity_manager.orm_default', true],
                 ],
             );
         $container->method('get')
             ->willReturnMap(
                 [
+                    ['config', $config],
                     [DependencyFactory::class, $this->createMock(DependencyFactory::class)],
                     [ConfigurationLoader::class, $this->createMock(ConfigurationLoader::class)],
                     ['doctrine.entity_manager.orm_default', $this->createMock(EntityManagerInterface::class)],


### PR DESCRIPTION
Allow multi-connection based migration other than just `orm_default`. This is useful if the migrations tables need to exist in multiple different databases or schemas.

e.g.

Config
```php
    'doctrine' => [
        ...
        'migrations' => [
            'orm_default' => [...],
            'orm_other_connection' => [...],
        ],
        ...
    ],
```

bin/doctrine
```php
$input = new ArgvInput();

/** @var string $em */
$em = $input->getParameterOption('--em', 'orm_default');


// hack to remove the --em option, cause it's not supported by the original ConsoleRunner.
foreach ($_SERVER['argv'] as $i => $arg) {
    if (str_starts_with($arg, '--em=')) {
        unset($_SERVER['argv'][$i]);
    }
}

try {
    $entityManager = $container->get('doctrine.entity_manager.' . $em);
} catch (NotFoundExceptionInterface $serviceNotFoundException) {
    throw new InvalidArgumentException(sprintf('Missing entity manager with name "%s"', $em));
}

$commandFactory = new CommandFactory($em);

$commands = [
    $commandFactory($container, Command\CurrentCommand::class),
    ...
];

...
```