### PR TITLE
`auto_generate_proxy_classes` instead of incorrect `generate_proxies`

### DIFF
--- a/example/full-config.php
+++ b/example/full-config.php
@@ -31,7 +31,7 @@ return [
                 'query_cache' => 'array',
                 'hydration_cache' => 'array',
                 'driver' => 'orm_default', // Actually defaults to the configuration config key, not hard-coded
-                'generate_proxies' => true,
+                'auto_generate_proxy_classes' => true,
                 'proxy_dir' => 'data/cache/DoctrineEntityProxy',
                 'proxy_namespace' => 'DoctrineEntityProxy',
                 'entity_namespaces' => [],


### PR DESCRIPTION
It seems it was always wrong in documentation, and always correct in code.