### PR TITLE
Upgraded `example/` to use a local composer reference

### DIFF
--- a/example/composer.json
+++ b/example/composer.json
@@ -1,15 +1,22 @@
 {
     "type": "project",
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.4.0 || ~8.5.0",
         "illuminate/container": "^12.43.1",
         "laminas/laminas-servicemanager": "^4.5.0",
+        "roave/psr-container-doctrine": "self.version",
         "symfony/cache": "^7.4.1"
     },
     "config": {
         "platform": {
-            "php": "8.2.99"
+            "php": "8.4.99"
         },
         "sort-packages": true
-    }
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../"
+        }
+    ]
 }

--- a/example/illuminate-container.php
+++ b/example/illuminate-container.php
@@ -7,7 +7,6 @@ use Illuminate\Container\Container;
 use Roave\PsrContainerDoctrine\EntityManagerFactory;
 
 require_once __DIR__ . '/vendor/autoload.php';
-require_once __DIR__ . '/../vendor/autoload.php';
 
 // Standard config keys
 $minimalConfig = require __DIR__ . '/minimal-config.php';

--- a/example/laminas-servicemanager.php
+++ b/example/laminas-servicemanager.php
@@ -7,7 +7,6 @@ use Laminas\ServiceManager\ServiceManager;
 use Roave\PsrContainerDoctrine\EntityManagerFactory;
 
 require_once __DIR__ . '/vendor/autoload.php';
-require_once __DIR__ . '/../vendor/autoload.php';
 
 // Standard config keys
 $minimalConfig                                                    = require __DIR__ . '/minimal-config.php';


### PR DESCRIPTION
Previously, our `example/composer.json` did not
consider the root package dependencies, therefore leading to incorrect SAT resolution.

This change makes it so that the `example/` don't depend on the root project's `composer.json`, but are
defining their own dependency graph instead.